### PR TITLE
Use CollectionProxy interface for has_many association

### DIFF
--- a/lib/rbs_active_hash/active_hash.rb
+++ b/lib/rbs_active_hash/active_hash.rb
@@ -140,7 +140,7 @@ module RbsActiveHash
           klass = options.fetch(:class_name, association_id.to_s.classify).constantize
 
           relation = if Object.const_defined?(:ActiveRecord) && klass.ancestors.include?(ActiveRecord::Base)
-                       "#{klass.name}::ActiveRecord_Relation"
+                       "#{klass.name}::ActiveRecord_Associations_CollectionProxy"
                      else
                        "Array[#{klass.name}]"
                      end

--- a/spec/rbs_active_hash/active_hash_spec.rb
+++ b/spec/rbs_active_hash/active_hash_spec.rb
@@ -156,7 +156,7 @@ RSpec.describe RbsActiveHash::ActiveHash do
             include ActiveHash::Associations
             extend ActiveHash::Associations::Methods
 
-            def items: () -> Item::ActiveRecord_Relation
+            def items: () -> Item::ActiveRecord_Associations_CollectionProxy
             def item_ids: () -> Array[Integer]
 
             def skills: () -> Array[Skill]


### PR DESCRIPTION
It seems that the `rbs_rails` gem assumes the use of `ActiveRecord_Associations_CollectionProxy` rather than `ActiveRecord_Relation`.

https://github.com/pocke/rbs_rails/blob/master/lib/rbs_rails/active_record.rb#L125-L141