### PR TITLE
chore: set persist-credentials: false in actions/checkout

### DIFF
--- a/.github/workflows/actionlint.yml
+++ b/.github/workflows/actionlint.yml
@@ -12,6 +12,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v6
+      with:
+        persist-credentials: false
     - name: Run actionlint
       shell: bash
       run: |

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -20,6 +20,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1.310.0
         with:

--- a/.github/workflows/rbs_collection.yml
+++ b/.github/workflows/rbs_collection.yml
@@ -16,6 +16,8 @@ jobs:
         app-id: ${{ vars.REPO_HOUSEKEEPER_APP_ID }}
         private-key: ${{ secrets.REPO_HOUSEKEEPER_PRIVATE_KEY }}
     - uses: actions/checkout@v6
+      with:
+        persist-credentials: false
     - name: Set up Ruby
       uses: ruby/setup-ruby@v1.310.0
       with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,6 +16,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1.310.0
         with:


### PR DESCRIPTION
## Summary

Set `persist-credentials: false` on every `actions/checkout` step to prevent the GitHub token from being written to a file under `$RUNNER_TEMP`, where it can be read (and base64-decoded) by any subsequent step.

The token-bearing config file is the default behavior of `actions/checkout`, and a compromised action or a script-injection bug elsewhere in the workflow can lift the token out of it. Turning credential persistence off removes that attack surface for the workflows that don't need to push back to the repo.

Reference: https://zenn.dev/kou_pg_0131/articles/gha-checkout-persist-credentials

## Test plan

- [x] `actionlint` passes
- [ ] Verify CI on this PR still runs to completion