### PR TITLE
Enable the rubocop-rbs_inline plugin

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -4,6 +4,7 @@ AllCops:
 
 plugins:
   - rubocop-rake
+  - rubocop-rbs_inline
   - rubocop-rspec
 
 Style/Documentation:
@@ -47,3 +48,12 @@ RSpec/NamedSubject:
 
 RSpec/MultipleExpectations:
   Max: 10
+
+Style/RbsInline/MissingTypeAnnotation:
+  EnforcedStyle: doc_style_and_return_annotation
+
+Style/RbsInline/RedundantTypeAnnotation:
+  EnforcedStyle: doc_style_and_return_annotation
+
+Style/RbsInline/RequireRbsInlineComment:
+  EnforcedStyle: never

--- a/Gemfile
+++ b/Gemfile
@@ -9,6 +9,7 @@ gem "rake", "~> 13.4"
 
 gem "rubocop", "~> 1.88"
 gem "rubocop-rake"
+gem "rubocop-rbs_inline"
 gem "rubocop-rspec"
 
 group :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -177,6 +177,10 @@ GEM
     rubocop-rake (0.7.1)
       lint_roller (~> 1.1)
       rubocop (>= 1.72.1)
+    rubocop-rbs_inline (1.5.5)
+      lint_roller (~> 1.1)
+      rbs-inline
+      rubocop (>= 1.72.1, < 2.0)
     rubocop-rspec (3.10.2)
       lint_roller (~> 1.1)
       regexp_parser (>= 2.0)
@@ -233,6 +237,7 @@ DEPENDENCIES
   rspec-daemon
   rubocop (~> 1.88)
   rubocop-rake
+  rubocop-rbs_inline
   rubocop-rspec
   steep
 


### PR DESCRIPTION
## Summary

This gem uses rbs-inline annotations in `lib` but did not lint them. Adds the `rubocop-rbs_inline` RuboCop plugin (and its cop configuration) to match the `init-ruby-project` skeleton, so the inline type annotations are checked by `rake rubocop` / `rake ci`.

## Changes

- `Gemfile` / `Gemfile.lock`: add `rubocop-rbs_inline`
- `.rubocop.yml`
  - add `rubocop-rbs_inline` to `plugins`
  - add `Style/RbsInline/*` settings (matching the skeleton):
    - `MissingTypeAnnotation` / `RedundantTypeAnnotation`: `doc_style_and_return_annotation`
    - `RequireRbsInlineComment`: `never`

🤖 Generated with [Claude Code](https://claude.com/claude-code)