### PR TITLE
Introduce rubocop-numbered-params

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -3,6 +3,7 @@ AllCops:
   NewCops: enable
 
 plugins:
+  - rubocop-numbered-params
   - rubocop-rake
   - rubocop-rbs_inline
   - rubocop-rspec

--- a/Gemfile
+++ b/Gemfile
@@ -8,6 +8,7 @@ gemspec
 gem "rake", "~> 13.4"
 
 gem "rubocop", "~> 1.88"
+gem "rubocop-numbered-params"
 gem "rubocop-rake"
 gem "rubocop-rbs_inline"
 gem "rubocop-rspec"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -174,6 +174,9 @@ GEM
     rubocop-ast (1.49.1)
       parser (>= 3.3.7.2)
       prism (~> 1.7)
+    rubocop-numbered-params (1.0.0)
+      lint_roller (~> 1.0)
+      rubocop (>= 1.72.1)
     rubocop-rake (0.7.1)
       lint_roller (~> 1.1)
       rubocop (>= 1.72.1)
@@ -236,6 +239,7 @@ DEPENDENCIES
   rspec
   rspec-daemon
   rubocop (~> 1.88)
+  rubocop-numbered-params
   rubocop-rake
   rubocop-rbs_inline
   rubocop-rspec

--- a/lib/rbs_active_hash/active_hash.rb
+++ b/lib/rbs_active_hash/active_hash.rb
@@ -98,7 +98,7 @@ module RbsActiveHash
           include ActiveHash::Enum
           extend ActiveHash::Enum::Methods
 
-          #{constants.map { |c| "#{c}: #{klass_name}" }.join("\n")}
+          #{constants.map { "#{_1}: #{klass_name}" }.join("\n")}
         RBS
       end
 
@@ -107,7 +107,7 @@ module RbsActiveHash
         return [] unless enum_accessors
 
         klass.data.filter_map do |record|
-          constant = enum_accessors.map { |name| record[name] }.join("_")
+          constant = enum_accessors.map { record[_1] }.join("_")
           next if constant.empty?
 
           constant.gsub!(/\W+/, "_")
@@ -121,7 +121,7 @@ module RbsActiveHash
         return if parser.scopes.empty?
 
         parser.scopes.map do |scope_id, args|
-          arguments = args.map { |arg| "untyped #{arg}" }.join(", ")
+          arguments = args.map { "untyped #{_1}" }.join(", ")
           <<~RBS.strip
             def self.#{scope_id}: (#{arguments}) -> ActiveHash::Relation[instance]
           RBS
@@ -204,7 +204,7 @@ module RbsActiveHash
         method_names = (klass.data || []).flat_map do |record|
           record.symbolize_keys.keys
         end
-        method_names.uniq.select { |k| valid_field_name?(k) }
+        method_names.uniq.select { valid_field_name?(_1) }
       end
 
       def method_types #: Hash[Symbol, untyped]
@@ -250,7 +250,7 @@ module RbsActiveHash
         elsif type.is_a? Class
           type.name.to_s
         elsif type.is_a? Array
-          types = type.map { |t| stringify_type(t) }.uniq.sort
+          types = type.map { stringify_type(_1) }.uniq.sort
           if types.delete("nil")
             "(#{types.join(" | ")})?"
           else

--- a/lib/rbs_active_hash/active_hash/parser.rb
+++ b/lib/rbs_active_hash/active_hash/parser.rb
@@ -108,7 +108,7 @@ module RbsActiveHash
         def node_to_literal(node) #: untyped
           case node.type
           when :LIST
-            node.children[...-1].map { |child| node_to_literal(child) }
+            node.children[...-1].map { node_to_literal(_1) }
           when :LIT, :STR, :SYM
             node.children.first
           when :HASH

--- a/rbs_active_hash.gemspec
+++ b/rbs_active_hash.gemspec
@@ -25,7 +25,7 @@ Gem::Specification.new do |spec|
     end
   end
   spec.bindir = "exe"
-  spec.executables = spec.files.grep(%r{\Aexe/}) { |f| File.basename(f) }
+  spec.executables = spec.files.grep(%r{\Aexe/}) { File.basename(_1) }
   spec.require_paths = ["lib"]
 
   spec.add_dependency "active_hash"

--- a/spec/rbs_active_hash/active_hash_spec.rb
+++ b/spec/rbs_active_hash/active_hash_spec.rb
@@ -67,7 +67,7 @@ end
 
 class Team < ActiveHash::Base
   scope :red, -> { where(colour: "red") }
-  scope :blue, ->(_obj) { where(colour: "blue") }
+  scope :blue, ->(_obj) { where(colour: "blue") } # rubocop:disable Style/PreferNumberedParameter
 end
 
 RSpec.describe RbsActiveHash::ActiveHash do


### PR DESCRIPTION
Add the `rubocop-numbered-params` plugin to enforce a consistent style for numbered block parameters, matching the setup already used in other repositories.

- Add `rubocop-numbered-params` to the Gemfile
- Register the plugin in `.rubocop.yml`

🤖 Generated with [Claude Code](https://claude.com/claude-code)