### PR TITLE
Align .rubocop.yml with shared skeleton baseline

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,6 +1,8 @@
+# NOTE: Rules are sorted in ASCII order.
+
 AllCops:
-  TargetRubyVersion: 3.2
   NewCops: enable
+  TargetRubyVersion: 3.2
 
 plugins:
   - rubocop-numbered-params
@@ -8,29 +10,21 @@ plugins:
   - rubocop-rbs_inline
   - rubocop-rspec
 
-Style/Documentation:
-  Enabled: false
-
-Style/StringLiterals:
-  Enabled: true
-  EnforcedStyle: double_quotes
-
-Style/StringLiteralsInInterpolation:
-  Enabled: true
-  EnforcedStyle: double_quotes
-
+# Layout
 Layout/LeadingCommentSpace:
   AllowRBSInlineAnnotation: true
+  AllowSteepAnnotation: true
 
 Layout/LineLength:
   Max: 120
 
+# Metrics
 Metrics/AbcSize:
   Max: 20
 
 Metrics/BlockLength:
   Exclude:
-    - spec/**/*_spec.rb
+    - "spec/**/*_spec.rb"
 
 Metrics/ClassLength:
   Max: 200
@@ -44,12 +38,23 @@ Metrics/MethodLength:
 Metrics/PerceivedComplexity:
   Max: 10
 
+# RSpec
+RSpec/ExampleLength:
+  Enabled: false
+
+RSpec/MultipleMemoizedHelpers:
+  Max: 10
+
+RSpec/MultipleExpectations:
+  Enabled: false
+
 RSpec/NamedSubject:
   Enabled: false
 
-RSpec/MultipleExpectations:
-  Max: 10
+RSpec/NestedGroups:
+  Max: 5
 
+# RbsInline
 Style/RbsInline/MissingTypeAnnotation:
   EnforcedStyle: doc_style_and_return_annotation
 
@@ -58,3 +63,22 @@ Style/RbsInline/RedundantTypeAnnotation:
 
 Style/RbsInline/RequireRbsInlineComment:
   EnforcedStyle: never
+
+# Style
+Style/AccessorGrouping:
+  Enabled: false
+
+Style/CommentedKeyword:
+  Enabled: false
+
+Style/Documentation:
+  Enabled: false
+
+Style/HashSyntax:
+  EnforcedShorthandSyntax: always
+
+Style/StringLiterals:
+  EnforcedStyle: double_quotes
+
+Style/StringLiteralsInInterpolation:
+  EnforcedStyle: double_quotes

--- a/lib/rbs_active_hash/active_hash.rb
+++ b/lib/rbs_active_hash/active_hash.rb
@@ -50,7 +50,7 @@ module RbsActiveHash
       def format(rbs) #: String
         parsed = RBS::Parser.parse_signature(rbs)
         StringIO.new.tap do |out|
-          RBS::Writer.new(out: out).write(parsed[1] + parsed[2])
+          RBS::Writer.new(out:).write(parsed[1] + parsed[2])
         end.string
       end
 


### PR DESCRIPTION
## Summary

Align this repository's `.rubocop.yml` with the shared `init-ruby-project`
skeleton so linting rules are consistent across all Ruby repositories, and
fix the offense the aligned config surfaces.

## Config changes

- Fill in missing cops: `Layout/LeadingCommentSpace` `AllowSteepAnnotation`,
  `RSpec/ExampleLength`, `RSpec/MultipleMemoizedHelpers`,
  `RSpec/NestedGroups`, `Style/AccessorGrouping`, `Style/CommentedKeyword`,
  `Style/HashSyntax`
- `RSpec/MultipleExpectations`: drop `Max: 10` and disable it to match the
  baseline
- Rules sorted in ASCII order to match the skeleton

Project-specific extensions (`Metrics/CyclomaticComplexity`,
`Metrics/PerceivedComplexity`) are preserved.

## Code changes (offense surfaced by the new cops)

- `active_hash.rb`: use `out:` shorthand (`Style/HashSyntax`)

Verified locally with `rubocop` (no offenses).

🤖 Generated with [Claude Code](https://claude.com/claude-code)