### PR TITLE
Add strscan to rbs_collection as a workaround

### DIFF
--- a/rbs_collection.lock.yaml
+++ b/rbs_collection.lock.yaml
@@ -297,6 +297,10 @@ gems:
   version: '0'
   source:
     type: stdlib
+- name: strscan
+  version: '0'
+  source:
+    type: stdlib
 - name: tempfile
   version: '0'
   source:

--- a/rbs_collection.yaml
+++ b/rbs_collection.yaml
@@ -16,3 +16,4 @@ path: .gem_rbs_collection
 gems:
   - name: steep
     ignore: true
+  - name: strscan


### PR DESCRIPTION
## Summary

`rbs validate` currently fails because of a bug in `rbs-inline`: the generated RBS references `StringScanner`, but `strscan`'s RBS is not loaded by the collection.

A fix has been submitted upstream. Until it is merged, this PR works around the failure by adding `strscan` to `rbs_collection.yaml` and reflecting it in the lock file.

## Changes

- Add `- name: strscan` to `rbs_collection.yaml`
- Add the corresponding `strscan` entry to `rbs_collection.lock.yaml`

🤖 Generated with [Claude Code](https://claude.com/claude-code)