### PR TITLE
Remove rubocop disable comment from Team scope definition

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -174,7 +174,7 @@ GEM
     rubocop-ast (1.50.0)
       parser (>= 3.3.7.2)
       prism (~> 1.7)
-    rubocop-numbered-params (1.0.0)
+    rubocop-numbered-params (1.0.1)
       lint_roller (~> 1.0)
       rubocop (>= 1.72.1)
     rubocop-rake (0.7.1)

--- a/spec/rbs_active_hash/active_hash_spec.rb
+++ b/spec/rbs_active_hash/active_hash_spec.rb
@@ -67,7 +67,7 @@ end
 
 class Team < ActiveHash::Base
   scope :red, -> { where(colour: "red") }
-  scope :blue, ->(_obj) { where(colour: "blue") } # rubocop:disable Style/PreferNumberedParameter
+  scope :blue, ->(_obj) { where(colour: "blue") }
 end
 
 RSpec.describe RbsActiveHash::ActiveHash do


### PR DESCRIPTION
This PR removes an unnecessary rubocop disable comment from the `Team` class scope definition in the test spec.

## Summary
Cleaned up a rubocop directive that was suppressing the `Style/PreferNumberedParameter` cop on the `blue` scope definition.

## Changes
- Removed the `# rubocop:disable Style/PreferNumberedParameter` comment from the `Team.blue` scope in the ActiveHash spec
- The scope definition remains functionally identical, using the `_obj` parameter name

## Details
The rubocop disable comment was likely added to allow the use of a named parameter (`_obj`) instead of a numbered parameter (`_1`). This change removes that suppression, suggesting either the rubocop configuration has been updated or the parameter naming convention is now acceptable for this codebase.

https://claude.ai/code/session_01UVSVAsskHwPJMtvDQnM8VA